### PR TITLE
feat: UID 注入とセッションログ特定 (#3)

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -72,6 +72,47 @@ describe('MCPServer', () => {
       expect(initResponse).toHaveProperty('capabilities');
     });
 
+    it('should include UID in initialization response', async () => {
+      const server = new MCPServer();
+      const initResponse = await server.handleInitialize({
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: {
+          name: 'test-client',
+          version: '1.0.0',
+        },
+      });
+
+      expect(initResponse).toHaveProperty('metadata');
+      expect(initResponse.metadata).toHaveProperty('uid');
+      expect(typeof initResponse.metadata!.uid).toBe('string');
+      expect(initResponse.metadata!.uid.length).toBeGreaterThan(0);
+    });
+
+    it('should generate different UIDs for different server instances', async () => {
+      const server1 = new MCPServer();
+      const initResponse1 = await server1.handleInitialize({
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: {
+          name: 'test-client',
+          version: '1.0.0',
+        },
+      });
+
+      const server2 = new MCPServer();
+      const initResponse2 = await server2.handleInitialize({
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: {
+          name: 'test-client',
+          version: '1.0.0',
+        },
+      });
+
+      expect(initResponse1.metadata!.uid).not.toBe(initResponse2.metadata!.uid);
+    });
+
     it('should return supported protocol version', async () => {
       const server = new MCPServer();
       const initResponse = await server.handleInitialize({

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -85,8 +85,9 @@ describe('MCPServer', () => {
 
       expect(initResponse).toHaveProperty('metadata');
       expect(initResponse.metadata).toHaveProperty('uid');
-      expect(typeof initResponse.metadata!.uid).toBe('string');
-      expect(initResponse.metadata!.uid.length).toBeGreaterThan(0);
+      expect(initResponse.metadata).toBeDefined();
+      expect(typeof initResponse.metadata?.uid).toBe('string');
+      expect(initResponse.metadata?.uid.length).toBeGreaterThan(0);
     });
 
     it('should generate different UIDs for different server instances', async () => {
@@ -110,7 +111,9 @@ describe('MCPServer', () => {
         },
       });
 
-      expect(initResponse1.metadata!.uid).not.toBe(initResponse2.metadata!.uid);
+      expect(initResponse1.metadata).toBeDefined();
+      expect(initResponse2.metadata).toBeDefined();
+      expect(initResponse1.metadata?.uid).not.toBe(initResponse2.metadata?.uid);
     });
 
     it('should return supported protocol version', async () => {

--- a/src/__tests__/session-cache.test.ts
+++ b/src/__tests__/session-cache.test.ts
@@ -1,0 +1,195 @@
+import { SessionCache } from '../session-cache';
+
+describe('SessionCache', () => {
+  let cache: SessionCache;
+
+  beforeEach(() => {
+    cache = new SessionCache();
+  });
+
+  describe('cache operations', () => {
+    it('should store and retrieve session info by UID', () => {
+      const uid = '550e8400-e29b-41d4-a716-446655440000';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cache.set(uid, sessionInfo);
+      const retrieved = cache.get(uid);
+
+      expect(retrieved).toEqual(sessionInfo);
+    });
+
+    it('should return null for non-existent UID', () => {
+      const result = cache.get('non-existent-uid');
+      expect(result).toBeNull();
+    });
+
+    it('should update existing cache entry', () => {
+      const uid = '550e8400-e29b-41d4-a716-446655440000';
+      const sessionInfo1 = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+      const sessionInfo2 = {
+        sessionFile: '/Users/test/.claude/projects/def456/session-999.jsonl',
+        projectHash: 'def456',
+        sessionId: 'session-999',
+      };
+
+      cache.set(uid, sessionInfo1);
+      cache.set(uid, sessionInfo2);
+
+      expect(cache.get(uid)).toEqual(sessionInfo2);
+    });
+
+    it('should check if UID exists in cache', () => {
+      const uid = '550e8400-e29b-41d4-a716-446655440000';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      expect(cache.has(uid)).toBe(false);
+
+      cache.set(uid, sessionInfo);
+
+      expect(cache.has(uid)).toBe(true);
+    });
+
+    it('should clear the cache', () => {
+      const uid1 = 'uid-1';
+      const uid2 = 'uid-2';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cache.set(uid1, sessionInfo);
+      cache.set(uid2, sessionInfo);
+
+      expect(cache.has(uid1)).toBe(true);
+      expect(cache.has(uid2)).toBe(true);
+
+      cache.clear();
+
+      expect(cache.has(uid1)).toBe(false);
+      expect(cache.has(uid2)).toBe(false);
+    });
+
+    it('should delete specific cache entry', () => {
+      const uid1 = 'uid-1';
+      const uid2 = 'uid-2';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cache.set(uid1, sessionInfo);
+      cache.set(uid2, sessionInfo);
+
+      cache.delete(uid1);
+
+      expect(cache.has(uid1)).toBe(false);
+      expect(cache.has(uid2)).toBe(true);
+    });
+  });
+
+  describe('cache expiration', () => {
+    it('should expire cache entries after TTL', () => {
+      jest.useFakeTimers();
+
+      const ttlMs = 15 * 60 * 1000; // 15 minutes
+      const cacheWithTTL = new SessionCache(ttlMs);
+
+      const uid = '550e8400-e29b-41d4-a716-446655440000';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cacheWithTTL.set(uid, sessionInfo);
+      expect(cacheWithTTL.get(uid)).toEqual(sessionInfo);
+
+      // Advance time by 14 minutes - should still be in cache
+      jest.advanceTimersByTime(14 * 60 * 1000);
+      expect(cacheWithTTL.get(uid)).toEqual(sessionInfo);
+
+      // Advance time by 2 more minutes (total 16 minutes) - should be expired
+      jest.advanceTimersByTime(2 * 60 * 1000);
+      expect(cacheWithTTL.get(uid)).toBeNull();
+
+      jest.useRealTimers();
+    });
+
+    it('should refresh TTL when entry is updated', () => {
+      jest.useFakeTimers();
+
+      const ttlMs = 15 * 60 * 1000; // 15 minutes
+      const cacheWithTTL = new SessionCache(ttlMs);
+
+      const uid = '550e8400-e29b-41d4-a716-446655440000';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cacheWithTTL.set(uid, sessionInfo);
+
+      // Advance time by 14 minutes
+      jest.advanceTimersByTime(14 * 60 * 1000);
+
+      // Update the entry - this should refresh the TTL
+      cacheWithTTL.set(uid, sessionInfo);
+
+      // Advance time by another 14 minutes (total 28 minutes from start)
+      jest.advanceTimersByTime(14 * 60 * 1000);
+
+      // Entry should still be in cache because TTL was refreshed
+      expect(cacheWithTTL.get(uid)).toEqual(sessionInfo);
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe('cache statistics', () => {
+    it('should track cache hits and misses', () => {
+      const uid1 = 'uid-1';
+      const uid2 = 'uid-2';
+      const sessionInfo = {
+        sessionFile: '/Users/test/.claude/projects/abc123/session-789.jsonl',
+        projectHash: 'abc123',
+        sessionId: 'session-789',
+      };
+
+      cache.set(uid1, sessionInfo);
+
+      // Cache hit
+      cache.get(uid1);
+      // Cache miss
+      cache.get(uid2);
+      // Another cache hit
+      cache.get(uid1);
+
+      const stats = cache.getStats();
+      expect(stats.hits).toBe(2);
+      expect(stats.misses).toBe(1);
+      expect(stats.hitRate).toBeCloseTo(0.667, 2);
+    });
+
+    it('should return zero hit rate when no requests made', () => {
+      const stats = cache.getStats();
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+      expect(stats.hitRate).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/session-discovery.test.ts
+++ b/src/__tests__/session-discovery.test.ts
@@ -52,7 +52,7 @@ describe('SessionDiscovery', () => {
     });
 
     it('should return null if UID is not found in any session', async () => {
-      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const _claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
 
       (fs.readdir as jest.Mock)
         .mockResolvedValueOnce([mockProjectHash])
@@ -169,8 +169,8 @@ describe('SessionDiscovery', () => {
     });
 
     it('should clear cache when requested', async () => {
-      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
-      const projectPath = path.join(claudeProjectsPath, mockProjectHash);
+      const _claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const _projectPath = path.join(_claudeProjectsPath, mockProjectHash);
       const sessionFile = `${mockSessionId}.jsonl`;
 
       (fs.readdir as jest.Mock)

--- a/src/__tests__/session-discovery.test.ts
+++ b/src/__tests__/session-discovery.test.ts
@@ -1,0 +1,198 @@
+import { SessionDiscovery } from '../session-discovery';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+jest.mock('fs/promises');
+jest.mock('os');
+
+describe('SessionDiscovery', () => {
+  const mockHomedir = '/Users/testuser';
+  const mockProjectHash = 'abc123def456';
+  const mockSessionId = 'session-789';
+  const mockUID = '550e8400-e29b-41d4-a716-446655440000';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (os.homedir as jest.Mock).mockReturnValue(mockHomedir);
+  });
+
+  describe('findSessionByUID', () => {
+    it('should find session file containing the specified UID', async () => {
+      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const projectPath = path.join(claudeProjectsPath, mockProjectHash);
+      const sessionFile = `${mockSessionId}.jsonl`;
+      const sessionFilePath = path.join(projectPath, sessionFile);
+
+      (fs.readdir as jest.Mock)
+        .mockResolvedValueOnce([mockProjectHash]) // List of project directories
+        .mockResolvedValueOnce([sessionFile, 'other-session.jsonl']); // Session files in project
+
+      const mockLogContent = [
+        '{"timestamp": 1234567890, "type": "init", "data": {}}',
+        `{"timestamp": 1234567891, "type": "server_response", "data": {"metadata": {"uid": "${mockUID}"}}}`,
+        '{"timestamp": 1234567892, "type": "request", "data": {}}',
+      ].join('\n');
+
+      (fs.readFile as jest.Mock).mockImplementation((filePath: string) => {
+        if (filePath === sessionFilePath) {
+          return Promise.resolve(mockLogContent);
+        }
+        return Promise.resolve('{"type": "other", "data": {}}');
+      });
+
+      const discovery = new SessionDiscovery();
+      const result = await discovery.findSessionByUID(mockUID);
+
+      expect(result).toEqual({
+        sessionFile: sessionFilePath,
+        projectHash: mockProjectHash,
+        sessionId: mockSessionId,
+      });
+    });
+
+    it('should return null if UID is not found in any session', async () => {
+      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+
+      (fs.readdir as jest.Mock)
+        .mockResolvedValueOnce([mockProjectHash])
+        .mockResolvedValueOnce(['session1.jsonl', 'session2.jsonl']);
+
+      (fs.readFile as jest.Mock).mockResolvedValue('{"type": "other", "data": {}}');
+
+      const discovery = new SessionDiscovery();
+      const result = await discovery.findSessionByUID('non-existent-uid');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle missing .claude directory gracefully', async () => {
+      (fs.readdir as jest.Mock).mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      const discovery = new SessionDiscovery();
+      const result = await discovery.findSessionByUID(mockUID);
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip invalid JSONL lines', async () => {
+      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const projectPath = path.join(claudeProjectsPath, mockProjectHash);
+      const sessionFile = `${mockSessionId}.jsonl`;
+      const sessionFilePath = path.join(projectPath, sessionFile);
+
+      (fs.readdir as jest.Mock)
+        .mockResolvedValueOnce([mockProjectHash])
+        .mockResolvedValueOnce([sessionFile]);
+
+      const mockLogContent = [
+        'invalid json line',
+        `{"timestamp": 1234567891, "type": "server_response", "data": {"metadata": {"uid": "${mockUID}"}}}`,
+        '{"timestamp": 1234567892, "type": "request", "data": {}}',
+      ].join('\n');
+
+      (fs.readFile as jest.Mock).mockResolvedValue(mockLogContent);
+
+      const discovery = new SessionDiscovery();
+      const result = await discovery.findSessionByUID(mockUID);
+
+      expect(result).toEqual({
+        sessionFile: sessionFilePath,
+        projectHash: mockProjectHash,
+        sessionId: mockSessionId,
+      });
+    });
+  });
+
+  describe('getClaudeProjectsPath', () => {
+    it('should return the correct path to Claude projects directory', () => {
+      const discovery = new SessionDiscovery();
+      const projectsPath = discovery.getClaudeProjectsPath();
+
+      expect(projectsPath).toBe(path.join(mockHomedir, '.claude', 'projects'));
+    });
+  });
+
+  describe('parseSessionFile', () => {
+    it('should extract session ID from filename', () => {
+      const discovery = new SessionDiscovery();
+
+      expect(discovery.parseSessionId('session-123.jsonl')).toBe('session-123');
+      expect(discovery.parseSessionId('complex-session-id-456.jsonl')).toBe('complex-session-id-456');
+      expect(discovery.parseSessionId('invalid-file.txt')).toBeNull();
+    });
+  });
+
+  describe('cache integration', () => {
+    it('should use cached result on second call', async () => {
+      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const projectPath = path.join(claudeProjectsPath, mockProjectHash);
+      const sessionFile = `${mockSessionId}.jsonl`;
+      const sessionFilePath = path.join(projectPath, sessionFile);
+
+      (fs.readdir as jest.Mock)
+        .mockResolvedValueOnce([mockProjectHash])
+        .mockResolvedValueOnce([sessionFile]);
+
+      const mockLogContent = `{"timestamp": 1234567891, "type": "server_response", "data": {"metadata": {"uid": "${mockUID}"}}}`;
+      (fs.readFile as jest.Mock).mockResolvedValue(mockLogContent);
+
+      const discovery = new SessionDiscovery();
+
+      // First call - should read from filesystem
+      const result1 = await discovery.findSessionByUID(mockUID);
+      expect(result1).toEqual({
+        sessionFile: sessionFilePath,
+        projectHash: mockProjectHash,
+        sessionId: mockSessionId,
+      });
+
+      // Clear mocks to ensure filesystem is not accessed again
+      jest.clearAllMocks();
+
+      // Second call - should use cache
+      const result2 = await discovery.findSessionByUID(mockUID);
+      expect(result2).toEqual({
+        sessionFile: sessionFilePath,
+        projectHash: mockProjectHash,
+        sessionId: mockSessionId,
+      });
+
+      // Verify filesystem was not accessed on second call
+      expect(fs.readdir).not.toHaveBeenCalled();
+      expect(fs.readFile).not.toHaveBeenCalled();
+
+      // Check cache statistics
+      const stats = discovery.getCacheStats();
+      expect(stats.hits).toBe(1);
+      expect(stats.misses).toBe(1);
+    });
+
+    it('should clear cache when requested', async () => {
+      const claudeProjectsPath = path.join(mockHomedir, '.claude', 'projects');
+      const projectPath = path.join(claudeProjectsPath, mockProjectHash);
+      const sessionFile = `${mockSessionId}.jsonl`;
+
+      (fs.readdir as jest.Mock)
+        .mockResolvedValue([mockProjectHash])
+        .mockResolvedValue([sessionFile]);
+
+      const mockLogContent = `{"timestamp": 1234567891, "type": "server_response", "data": {"metadata": {"uid": "${mockUID}"}}}`;
+      (fs.readFile as jest.Mock).mockResolvedValue(mockLogContent);
+
+      const discovery = new SessionDiscovery();
+
+      // First call - populate cache
+      await discovery.findSessionByUID(mockUID);
+
+      // Clear cache
+      discovery.clearCache();
+
+      // Next call should hit filesystem again
+      await discovery.findSessionByUID(mockUID);
+
+      // Both calls should have hit the filesystem
+      expect(fs.readdir).toHaveBeenCalledTimes(4); // 2 calls per findSessionByUID
+    });
+  });
+});

--- a/src/__tests__/uid-manager.test.ts
+++ b/src/__tests__/uid-manager.test.ts
@@ -1,0 +1,69 @@
+import { UIDManager } from '../uid-manager';
+
+describe('UIDManager', () => {
+  describe('UID generation', () => {
+    it('should generate a unique identifier', () => {
+      const uid = UIDManager.generateUID();
+      expect(uid).toBeDefined();
+      expect(typeof uid).toBe('string');
+      expect(uid.length).toBeGreaterThan(0);
+    });
+
+    it('should generate different UIDs on each call', () => {
+      const uid1 = UIDManager.generateUID();
+      const uid2 = UIDManager.generateUID();
+      expect(uid1).not.toBe(uid2);
+    });
+
+    it('should follow UUID v4 format', () => {
+      const uid = UIDManager.generateUID();
+      const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(uid).toMatch(uuidV4Regex);
+    });
+  });
+
+  describe('UID storage', () => {
+    it('should store the current UID', () => {
+      const uid = UIDManager.generateUID();
+      UIDManager.setCurrentUID(uid);
+      expect(UIDManager.getCurrentUID()).toBe(uid);
+    });
+
+    it('should return null if no UID is set', () => {
+      const manager = new UIDManager();
+      expect(manager.getUID()).toBeNull();
+    });
+
+    it('should update the current UID', () => {
+      const uid1 = UIDManager.generateUID();
+      const uid2 = UIDManager.generateUID();
+
+      UIDManager.setCurrentUID(uid1);
+      expect(UIDManager.getCurrentUID()).toBe(uid1);
+
+      UIDManager.setCurrentUID(uid2);
+      expect(UIDManager.getCurrentUID()).toBe(uid2);
+    });
+  });
+
+  describe('UID in initialization response', () => {
+    it('should include UID in the server metadata', () => {
+      const manager = new UIDManager();
+      const uid = manager.initialize();
+      const metadata = manager.getMetadata();
+
+      expect(metadata.uid).toBe(uid);
+      expect(metadata.timestamp).toBeDefined();
+    });
+
+    it('should generate a new UID on initialization', () => {
+      const manager = new UIDManager();
+      const uid1 = manager.initialize();
+
+      const manager2 = new UIDManager();
+      const uid2 = manager2.initialize();
+
+      expect(uid1).not.toBe(uid2);
+    });
+  });
+});

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1,4 +1,4 @@
-interface SessionInfo {
+export interface SessionInfo {
   sessionFile: string;
   projectHash: string;
   sessionId: string;
@@ -9,7 +9,7 @@ interface CacheEntry {
   timestamp: number;
 }
 
-interface CacheStats {
+export interface CacheStats {
   hits: number;
   misses: number;
   hitRate: number;

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1,0 +1,96 @@
+interface SessionInfo {
+  sessionFile: string;
+  projectHash: string;
+  sessionId: string;
+}
+
+interface CacheEntry {
+  data: SessionInfo;
+  timestamp: number;
+}
+
+interface CacheStats {
+  hits: number;
+  misses: number;
+  hitRate: number;
+}
+
+export class SessionCache {
+  private cache: Map<string, CacheEntry>;
+  private ttlMs: number;
+  private hits: number;
+  private misses: number;
+
+  constructor(ttlMs: number = 15 * 60 * 1000) {
+    // Default TTL: 15 minutes
+    this.cache = new Map();
+    this.ttlMs = ttlMs;
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  set(uid: string, sessionInfo: SessionInfo): void {
+    this.cache.set(uid, {
+      data: sessionInfo,
+      timestamp: Date.now(),
+    });
+  }
+
+  get(uid: string): SessionInfo | null {
+    const entry = this.cache.get(uid);
+
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    // Check if entry has expired
+    const now = Date.now();
+    if (now - entry.timestamp > this.ttlMs) {
+      // Entry has expired, remove it
+      this.cache.delete(uid);
+      this.misses++;
+      return null;
+    }
+
+    this.hits++;
+    return entry.data;
+  }
+
+  has(uid: string): boolean {
+    const entry = this.cache.get(uid);
+
+    if (!entry) {
+      return false;
+    }
+
+    // Check if entry has expired
+    const now = Date.now();
+    if (now - entry.timestamp > this.ttlMs) {
+      // Entry has expired, remove it
+      this.cache.delete(uid);
+      return false;
+    }
+
+    return true;
+  }
+
+  delete(uid: string): void {
+    this.cache.delete(uid);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  getStats(): CacheStats {
+    const total = this.hits + this.misses;
+    const hitRate = total === 0 ? 0 : this.hits / total;
+
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      hitRate,
+    };
+  }
+}

--- a/src/session-discovery.ts
+++ b/src/session-discovery.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { SessionCache } from './session-cache';
+
+interface SessionInfo {
+  sessionFile: string;
+  projectHash: string;
+  sessionId: string;
+}
+
+export class SessionDiscovery {
+  private claudeProjectsPath: string;
+  private cache: SessionCache;
+
+  constructor() {
+    this.claudeProjectsPath = this.getClaudeProjectsPath();
+    this.cache = new SessionCache();
+  }
+
+  getClaudeProjectsPath(): string {
+    return path.join(os.homedir(), '.claude', 'projects');
+  }
+
+  parseSessionId(filename: string): string | null {
+    if (!filename.endsWith('.jsonl')) {
+      return null;
+    }
+    return filename.replace('.jsonl', '');
+  }
+
+  async findSessionByUID(uid: string): Promise<SessionInfo | null> {
+    // Check cache first
+    const cachedSession = this.cache.get(uid);
+    if (cachedSession) {
+      return cachedSession;
+    }
+
+    try {
+      // Read all project directories
+      const projectDirs = await fs.readdir(this.claudeProjectsPath);
+
+      for (const projectHash of projectDirs) {
+        const projectPath = path.join(this.claudeProjectsPath, projectHash);
+
+        try {
+          // Read all session files in the project directory
+          const sessionFiles = await fs.readdir(projectPath);
+
+          for (const sessionFile of sessionFiles) {
+            if (!sessionFile.endsWith('.jsonl')) {
+              continue;
+            }
+
+            const sessionFilePath = path.join(projectPath, sessionFile);
+
+            // Read and check the session file for the UID
+            const content = await fs.readFile(sessionFilePath, 'utf-8');
+            const lines = content.split('\n');
+
+            for (const line of lines) {
+              if (!line.trim()) {
+                continue;
+              }
+
+              try {
+                const entry = JSON.parse(line);
+
+                // Check if this entry contains our UID
+                if (
+                  entry?.type === 'server_response' &&
+                  entry?.data?.metadata?.uid === uid
+                ) {
+                  const sessionId = this.parseSessionId(sessionFile);
+                  if (sessionId) {
+                    const sessionInfo: SessionInfo = {
+                      sessionFile: sessionFilePath,
+                      projectHash,
+                      sessionId,
+                    };
+                    // Store in cache before returning
+                    this.cache.set(uid, sessionInfo);
+                    return sessionInfo;
+                  }
+                }
+              } catch (parseError) {
+                // Skip invalid JSON lines
+                continue;
+              }
+            }
+          }
+        } catch (projectError) {
+          // Skip inaccessible project directories
+          continue;
+        }
+      }
+
+      return null;
+    } catch (error) {
+      // Handle missing .claude directory or other errors
+      return null;
+    }
+  }
+
+  getCacheStats() {
+    return this.cache.getStats();
+  }
+
+  clearCache() {
+    this.cache.clear();
+  }
+}

--- a/src/session-discovery.ts
+++ b/src/session-discovery.ts
@@ -2,12 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { SessionCache } from './session-cache';
-
-interface SessionInfo {
-  sessionFile: string;
-  projectHash: string;
-  sessionId: string;
-}
+import type { SessionInfo, CacheStats } from './session-cache';
 
 export class SessionDiscovery {
   private claudeProjectsPath: string;
@@ -102,7 +97,7 @@ export class SessionDiscovery {
     }
   }
 
-  getCacheStats() {
+  getCacheStats(): CacheStats {
     return this.cache.getStats();
   }
 

--- a/src/uid-manager.ts
+++ b/src/uid-manager.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from 'crypto';
+
+interface UIDMetadata {
+  uid: string;
+  timestamp: number;
+}
+
+export class UIDManager {
+  private static currentUID: string | null = null;
+  private uid: string | null = null;
+  private metadata: UIDMetadata | null = null;
+
+  static generateUID(): string {
+    return randomUUID();
+  }
+
+  static setCurrentUID(uid: string): void {
+    UIDManager.currentUID = uid;
+  }
+
+  static getCurrentUID(): string | null {
+    return UIDManager.currentUID;
+  }
+
+  getUID(): string | null {
+    return this.uid;
+  }
+
+  initialize(): string {
+    this.uid = UIDManager.generateUID();
+    this.metadata = {
+      uid: this.uid,
+      timestamp: Date.now(),
+    };
+    return this.uid;
+  }
+
+  getMetadata(): UIDMetadata {
+    if (!this.metadata) {
+      throw new Error('UIDManager not initialized');
+    }
+    return this.metadata;
+  }
+}


### PR DESCRIPTION
## 📝 概要
Claude Code のログから対象セッションを特定できる仕組みを実装しました。

## ✅ 変更内容
- [x] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] テスト追加・修正
- [ ] CI/CD改善

### 実装内容
- MCP 初期化時に UID を生成して返す機能を実装
- Claude Code のログに UID が記録される仕組みを実装
- `~/.claude/projects/{project-hash}/{session-id}.jsonl` を探索し、UID を含むファイルを特定する機能を実装
- キャッシュ機構を導入し、毎回の探索を避ける仕組みを実装

## 🧪 テスト
- [x] 単体テストを追加/更新
- [ ] 統合テストを実行
- [ ] 手動テストを実行
- [x] すべてのテストがパス

## 📦 品質チェック
- [x] TypeScript型チェック: パス
- [x] ESLintコード品質: パス
- [x] ビルドエラーなし
- [ ] セキュリティ監査: パス

## 🔗 関連Issue
Closes #3

## 📚 その他
TDDアプローチで実装を進めました。以下のコンポーネントを追加：
- `UIDManager`: UID生成と管理
- `SessionDiscovery`: セッションログファイルの探索とUID照合
- `SessionCache`: 15分間のTTL付きキャッシュ機構

---
**チェックリスト**
- [x] 自分でコードレビューを実施
- [ ] 適切なラベルを設定
- [ ] 必要に応じてドキュメントを更新
- [ ] 破壊的変更がある場合は明記