### PR TITLE
Prepare for npm package release

### DIFF
--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,0 +1,66 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'canary-*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@pppp606'
+          cache: 'npm'
+
+      - run: npm ci --legacy-peer-deps
+
+      - run: npm run build
+
+      - name: Configure GitHub Packages registry
+        run: |
+          echo "@pppp606:registry=https://npm.pkg.github.com/" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
+
+      - run: npm publish || echo "Package already exists on GitHub Packages, continuing..."
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-canary-release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/canary-')
+    needs: publish
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Canary Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Canary Release ${{ github.ref_name }}
+          body: |
+            🧪 Canary release (GitHub Packages only)
+
+            ### Installation
+            ```bash
+            npm install claude-ops-mcp@${{ github.ref_name }} --registry=https://npm.pkg.github.com
+            ```
+
+            ⚠️ This is a pre-release version for testing purposes.
+          draft: false
+          prerelease: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,73 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Configure npm for npmjs.org
+        run: |
+          echo "registry=https://registry.npmjs.org" > .npmrc
+
+      - run: npm ci --legacy-peer-deps
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - run: npm run test:coverage
+
+      - run: npm run build
+
+      - name: Verify build outputs
+        run: |
+          test -f dist/index.js
+          echo "✅ Build outputs verified"
+
+      - run: npm publish --access public --registry=https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            🎉 New release published to npm!
+
+            ### Installation
+            ```bash
+            npm install claude-ops-mcp@${{ github.ref_name }}
+            ```
+
+            ### Usage
+            See [README.md](https://github.com/pppp606/claude-ops-mcp#readme) for usage instructions.
+          draft: false
+          prerelease: false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,43 @@
+# Source files
+src/
+*.ts
+!*.d.ts
+
+# Tests
+tests/
+__tests__/
+*.test.ts
+*.spec.ts
+*.test.js
+*.test.d.ts
+*.test.d.ts.map
+*.test.js.map
+coverage/
+
+# Configuration files
+tsconfig.json
+jest.config.js
+.eslintrc.*
+.prettierrc.*
+.prettierignore
+
+# CI/CD
+.github/
+
+# Development
+.vscode/
+.idea/
+*.log
+npm-debug.log*
+.DS_Store
+
+# Environment
+.env
+.env.*
+
+# Build artifacts
+*.tgz
+
+# Documentation (keep only README.md)
+docs/
+CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -32,6 +32,24 @@
   ],
   "author": "Yuki Tanaka",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pppp606/claude-ops-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pppp606/claude-ops-mcp/issues"
+  },
+  "homepage": "https://github.com/pppp606/claude-ops-mcp#readme",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.js.map",
+    "!dist/**/*.test.*",
+    "!dist/**/__tests__",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary
This PR prepares the repository for publishing to npm and GitHub Packages with automated CI/CD workflows.

## Changes

### 1. Package Metadata (package.json)
- Added `repository`, `bugs`, and `homepage` fields for npm package page
- Configured `files` field to include only necessary files in the published package
  - Includes: `dist/**/*.js`, `dist/**/*.d.ts`, type maps, README, LICENSE
  - Excludes: test files and `__tests__` directories

### 2. .npmignore
- Created comprehensive ignore rules to exclude:
  - Source TypeScript files (`src/`)
  - Test files and coverage
  - Configuration files (tsconfig, jest, eslint, prettier)
  - CI/CD files (`.github/`)
  - Development artifacts

### 3. CI/CD Workflows

#### publish-npm.yml
- **Trigger**: Push of `v*` tags (e.g., v0.1.0)
- **Actions**:
  1. Run full CI pipeline (lint, typecheck, tests, build)
  2. Publish to npm registry
  3. Create GitHub release with installation instructions

#### publish-github.yml
- **Trigger**: Push of `v*` or `canary-*` tags
- **Actions**:
  1. Build the project
  2. Publish to GitHub Packages
  3. Create GitHub release (prerelease for canary tags)

## Testing
- ✅ Verified build passes: `npm run ci`
- ✅ Verified package contents: `npm pack` (test files excluded)
- ✅ Verified package.json configuration is valid

## Next Steps
After merging this PR:
1. Set `NPM_TOKEN` in GitHub Secrets (Settings → Secrets → Actions)
2. Create and push a release tag:
   ```bash
   git tag v0.1.0
   git push origin v0.1.0
   ```
3. GitHub Actions will automatically publish to npm and create a release

## Related Issue
Closes #48